### PR TITLE
refactor: board 페이지 loader연동

### DIFF
--- a/src/Action.jsx
+++ b/src/Action.jsx
@@ -1,0 +1,17 @@
+// import { db } from "./firebase";
+// import { collection, addDoc, serverTimestamp } from "firebase/firestore";
+
+// export const addPostAction = async ({ request }) => {
+//   const formData = await request.formData();
+//   const newPost = {
+//     title: formData.get("title"),
+//     content: formData.get("content"),
+//     nickname: formData.get("nickname"),
+//     rating: Number(formData.get("rating")) || 0,
+//     replyCount: 0,
+//     createdAt: serverTimestamp(),
+//   };
+
+//   await addDoc(collection(db, "contents"), newPost);
+//   return null;
+// };

--- a/src/Components/Board/BoardList.jsx
+++ b/src/Components/Board/BoardList.jsx
@@ -1,73 +1,41 @@
-import {
-  collection,
-  limit,
-  onSnapshot,
-  orderBy,
-  query,
-} from "firebase/firestore";
-import React, { useEffect, useState } from "react";
-import { db } from "../../firebase";
-
+import React, { useState } from "react";
 import "./BoardList.css";
-
 import getRelativeTime from "../getRelativeTime ";
+import { Link, useLoaderData, useSearchParams } from "react-router-dom";
 
 const BoardList = () => {
-  const [contents, setContents] = useState([]);
-  const [sortValue, setSortValue] = useState("최신순");
   const [isOpen, setIsOpen] = useState(false);
-  console.log(contents);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const { contents = [] } = useLoaderData();
+
+  const sortValue = searchParams.get("sort") || "createdAt";
 
   const handleDropdown = () => {
     setIsOpen(!isOpen);
   };
 
-  const handleDropdownClick = (item) => {
-    setSortValue(item);
-    setIsOpen(false);
+  const handleSortChange = (value) => {
+    const sortParam =
+      value === "최신순"
+        ? "createdAt"
+        : value === "별점순"
+        ? "rating"
+        : "replyCount";
+
+    setSearchParams({ sort: sortParam });
   };
-  useEffect(() => {
-    let unsubscribe = null;
-
-    const fetchContents = async (orderField = "createdAt") => {
-      const contentsQuery = query(
-        collection(db, "contents"),
-        orderBy(orderField, "desc"),
-        limit(25)
-      );
-
-      unsubscribe = await onSnapshot(contentsQuery, (snapshot) => {
-        const contents = snapshot.docs.map((doc) => {
-          const { password, ...rest } = doc.data();
-          return {
-            ...rest,
-            id: doc.id,
-          };
-        });
-        setContents(contents);
-      });
-    };
-
-    if (sortValue === "최신순") {
-      fetchContents("createdAt");
-    } else if (sortValue === "별점순") {
-      fetchContents("rating");
-    } else {
-      fetchContents("replyCount");
-    }
-
-    return () => {
-      if (unsubscribe) {
-        unsubscribe();
-      }
-    };
-  }, [sortValue]);
 
   return (
     <div className="board-list-wrapper">
       <div className="board-list-header">
         <div onClick={handleDropdown} className="board-dropdown-wrapper">
-          <button className="board-dropdown">{sortValue}</button>
+          <button className="board-dropdown">
+            {sortValue === "createdAt"
+              ? "최신순"
+              : sortValue === "rating"
+              ? "별점순"
+              : "댓글순"}
+          </button>
           <svg
             fill="none"
             strokeWidth="1.5"
@@ -85,15 +53,9 @@ const BoardList = () => {
 
           {isOpen && (
             <div className="board-dropdown-button">
-              <button onClick={() => handleDropdownClick("최신순")}>
-                최신순
-              </button>
-              <button onClick={() => handleDropdownClick("별점순")}>
-                별점순
-              </button>
-              <button onClick={() => handleDropdownClick("댓글순")}>
-                댓글순
-              </button>
+              <button onClick={() => handleSortChange("최신순")}>최신순</button>
+              <button onClick={() => handleSortChange("별점순")}>별점순</button>
+              <button onClick={() => handleSortChange("댓글순")}>댓글순</button>
             </div>
           )}
         </div>
@@ -102,16 +64,16 @@ const BoardList = () => {
         <section className="board-list-body" key={content.id}>
           <div>
             {content.replyCount > 0 ? (
-              <a className="board-list-link" href={`/board/${content.id}`}>
+              <Link className="board-list-link" to={`/board/${content.id}`}>
                 {content.title}{" "}
                 <span className="board-list-replyCount">
                   [{content.replyCount}]
                 </span>
-              </a>
+              </Link>
             ) : (
-              <a className="board-list-link" href={`/board/${content.id}`}>
+              <Link className="board-list-link" to={`/board/${content.id}`}>
                 {content.title}
-              </a>
+              </Link>
             )}
           </div>
           <div className="board-footer">

--- a/src/Components/Nav/Nav.jsx
+++ b/src/Components/Nav/Nav.jsx
@@ -39,8 +39,6 @@ const Nav = () => {
         </div>
 
         <nav className="navButton">
-          <Link to="#aboutSection">About</Link>
-
           <div className="projects-links-box">
             <p onClick={() => setIsOpenProjectList(!isOpenProjectList)}>
               Projects
@@ -71,8 +69,6 @@ const Nav = () => {
           </a>
         </div>
         <nav className="navButton">
-          <Link to="#aboutSection">About</Link>
-
           <div className="projects-links-box">
             <p onClick={() => setIsOpenProjectList(!isOpenProjectList)}>
               Projects

--- a/src/Loader.jsx
+++ b/src/Loader.jsx
@@ -1,0 +1,25 @@
+// loaders.js
+import { db } from "./firebase";
+import { collection, getDocs, orderBy, query, limit } from "firebase/firestore";
+
+export const boardListLoader = async ({ request }) => {
+  const url = new URL(request.url);
+  const sortValue = url.searchParams.get("sort") || "createdAt"; // 기본값: 최신순
+
+  const contentsQuery = query(
+    collection(db, "contents"),
+    orderBy(sortValue, "desc"),
+    limit(25)
+  );
+
+  const querySnapshot = await getDocs(contentsQuery);
+  const contents = querySnapshot.docs.map((doc) => {
+    const { password, ...rest } = doc.data();
+    return {
+      ...rest,
+      id: doc.id,
+    };
+  });
+
+  return { contents, sortValue };
+};

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -12,6 +12,8 @@ import BoardContent from "./routes/board/[id]";
 import BoardLayout from "./Components/Layout/BoardLayout";
 import { AuthProvider } from "./contexts/AuthContext";
 import LenisProvider from "./contexts/LenisProvider";
+import { boardListLoader } from "./Loader";
+import { addPostAction } from "./Action";
 
 const router = createBrowserRouter([
   {
@@ -35,6 +37,8 @@ const router = createBrowserRouter([
           {
             index: true,
             element: <Board />,
+            loader: boardListLoader,
+            action: addPostAction,
           },
           {
             path: ":id",

--- a/src/routes/board/[id]/index.jsx
+++ b/src/routes/board/[id]/index.jsx
@@ -9,7 +9,7 @@ import {
 } from "firebase/firestore";
 import React, { useEffect, useMemo, useState } from "react";
 import { auth, db } from "../../../firebase";
-import { useParams } from "react-router-dom";
+import { Link, useParams } from "react-router-dom";
 import "./boardContent.css";
 import Star from "../../../Components/Star";
 import BoardEdit from "../../../Components/Board/BoardEdit";
@@ -178,9 +178,9 @@ const BoardContent = () => {
         <div className="board-content-wrapper">
           <div className="board-content-detail-header">
             <div className="board-content-detail-header-top">
-              <a className="board-content-detail-header-link" href="/board">
+              <Link className="board-content-detail-header-link" to="/board">
                 자유게시판
-              </a>
+              </Link>
               <Star star={content.rating} />
               <h2 className="board-content-detail-header-title">
                 {content.title}


### PR DESCRIPTION
 ✅ 1. 기존 방식 (onSnapshot 단독 사용)
장점
1. Firestore에서 실시간 데이터를 감지하여 빠르게 UI 반영
2. useEffect에서 onSnapshot을 구독하여 데이터 변경 시 즉시 업데이트

단점
1. 초기 데이터 로딩 시 지연 가능: onSnapshot은 데이터 변경 사항을 실시간으로 감지하지만, 초기 데이터를 가져오는 속도는 getDocs보다 느릴 수 있음
2. 불필요한 Firebase 호출 가능: 라우트 이동할 때마다 onSnapshot이 구독을 새로 생성하여 여러 번 실행될 가능성이 있음

✅ 2. Loader + onSnapshot 적용 후
장점
1. 초기 데이터 로딩 속도 향상: loader에서 getDocs를 통해 초기 데이터를 빠르게 가져옴
2. 최적화된 리렌더링: 초기 데이터가 빠르게 로딩되고, 이후 변경 사항은 onSnapshot으로 실시간 반영
3. 불필요한 Firebase 호출 감소: loader에서 데이터를 먼저 불러오고, 컴포넌트 마운트 이후에만 onSnapshot을 실행하여 중복 구독 방지

 단점
1. 초기 구현이 다소 복잡해짐 (loader와 onSnapshot을 함께 사용해야 함)


<img width="181" alt="image" src="https://github.com/user-attachments/assets/4c8b6f29-a1e5-4072-adf5-4ac83125ef33" />
boardpage에 sort 값 추가, loader에서 sort 값을 받아 최신순, 별점순, 댓글순 으로 정렬