### PR TITLE
fix: 대댓글 path 필드 배열로 저장

### DIFF
--- a/src/Components/Board/SubReplySubmit.jsx
+++ b/src/Components/Board/SubReplySubmit.jsx
@@ -31,7 +31,7 @@ const SubReplySubmit = ({
         createdAt: Date.now(),
         depth: parent ? parent.depth + 1 : 0,
         parentId: parentId,
-        path: parent ? `${parent.path}/${parent.id}` : "",
+        path: parent ? [...parent.path, parentId] : ["root"],
       });
 
       const boardDocRef = doc(db, "contents", boardId);

--- a/src/routes/board/[id]/index.jsx
+++ b/src/routes/board/[id]/index.jsx
@@ -53,7 +53,7 @@ const BoardContent = () => {
         createdAt: Date.now(),
         depth: parent ? parent.depth + 1 : 0,
         parentId: parent ? parent.id : null,
-        path: parent ? `${parent.path}/${parent.id}` : "",
+        path: parent ? [...parent.path, parent.id] : ["root"],
       });
 
       const boardDocRef = doc(db, "contents", boardId);
@@ -307,6 +307,7 @@ const BoardContent = () => {
                                 boardId={boardId}
                                 parentId={r.id}
                                 parent={r}
+                                setOpenReplyId={setOpenReplyId}
                               />
                             )}
                             {/* 🔽 대댓글 컴포넌트 추가 */}


### PR DESCRIPTION
<img width="310" alt="image" src="https://github.com/user-attachments/assets/24e1dd54-7615-4138-99c3-c62013ead442" />

기존 "/"로 구분하던 방식에서 배열로 변경